### PR TITLE
Changes "Place Pairing File" buttons to "Place"

### DIFF
--- a/src/pages/Pairing.tsx
+++ b/src/pages/Pairing.tsx
@@ -79,7 +79,7 @@ export const Pairing = () => {
                     <td className="cert-item-part">{app.name}</td>
                     <td className="cert-item-part">{app.bundleId}</td>
                     <td className="cert-item-revoke" onClick={() => pair(app)}>
-                      Place Pairing File
+                      Place
                     </td>
                   </tr>
                 ))}


### PR DESCRIPTION
Given that "Place Pairing File" already shows above the buttons, this should be shorter, less redundant, and more asthetically pleasing