### PR TITLE
Add NexStore support for iloader

### DIFF
--- a/src-tauri/src/pairing.rs
+++ b/src-tauri/src/pairing.rs
@@ -26,6 +26,7 @@ const PAIRING_APPS: &[(&str, &str)] = &[
     ("SparseBox", "pairingFile.plist"),
     ("StikStore", "pairingFile.plist"),
     ("ByeTunes", "pairing file/pairingFile.plist"),
+    ("NexStore", "pairingFile.plist"),
 ];
 
 async fn pairing_file(


### PR DESCRIPTION
Hello,

I was wondering if it would be possible to add support for NexStore in iLoader.

**NexStore Website:** https://nexstore.novadev.vip  
**GitHub:** https://github.com/novadev404/nexstore

Just to clarify, NexStore is not related to ProStore in any way.

Thanks,  
NovaDev404