### PR TITLE
Fix nested Tokio runtime panic in main.rs

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -17,5 +17,9 @@ fn main() {
         .install_default()
         .expect("Failed to install rustls crypto provider");
     isideload::init().expect("Failed to initialize error reporting");
-    iloader_lib::run()
+
+    // Run iloader safely in a blocking context
+    tokio::task::block_in_place(|| {
+        iloader_lib::run()
+    });
 }


### PR DESCRIPTION
Problem:
iloader_lib::run() could panic with "Cannot start a runtime from within a runtime" when run inside an existing Tokio runtime.

Solution:
Wrap the call in `tokio::task::block_in_place()` so it can safely create its own runtime without conflicting with the existing async executor.
iloader doesn't sign in #296