### PR TITLE
feat: add MiniStore pairing file support

### DIFF
--- a/src-tauri/src/pairing.rs
+++ b/src-tauri/src/pairing.rs
@@ -13,6 +13,7 @@ use crate::device::{DeviceInfo, DeviceInfoMutex, get_provider, get_provider_from
 
 const PAIRING_APPS: &[(&str, &str)] = &[
     ("SideStore", "ALTPairingFile.mobiledevicepairing"),
+    ("MiniStore", "ALTPairingFile.mobiledevicepairing"),
     (
         "LiveContainer",
         "SideStore/Documents/ALTPairingFile.mobiledevicepairing",


### PR DESCRIPTION
MiniStore (https://github.com/The-Big-Mini/MiniStore) is a fork of SideStore. It uses the identical pairing file name and location (`ALTPairingFile.mobiledevicepairing` in the app's Documents directory), so it only needs a one-line addition to `PAIRING_APPS`.

This lets ILoader detect and auto-install the pairing file for MiniStore users the same way it does for SideStore.