### PR TITLE
Add Nix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Install SideStore (or other apps) and import your pairing file with ease
     - macOS: Included
     - Linux: Potentially included, if not, install via your package manager
 - Install the latest version for your platform from the [releases](https://github.com/nab138/iloader/releases)
+    - NixOS: Use the flake `github:nab138/iloader`
 - Plug in your iDevice to your computer
 - Open the app
 - Sign into your Apple ID

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,12 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    nodeName = lock.nodes.root.inputs.flake-compat;
+  in
+  fetchTarball {
+    url =
+      lock.nodes.${nodeName}.locked.url
+        or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.${nodeName}.locked.rev}.tar.gz";
+    sha256 = lock.nodes.${nodeName}.locked.narHash;
+  }
+) { src = ./.; }).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,204 @@
+{
+  "nodes": {
+    "bun2nix": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "import-tree": "import-tree",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1770895533,
+        "narHash": "sha256-v3QaK9ugy9bN9RXDnjw0i2OifKmz2NnKM82agtqm/UY=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "c843f477b15f51151f8c6bcc886954699440a6e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1769996383,
+        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "import-tree": {
+      "locked": {
+        "lastModified": 1763762820,
+        "narHash": "sha256-ZvYKbFib3AEwiNMLsejb/CWs/OL/srFQ8AogkebEPF0=",
+        "owner": "vic",
+        "repo": "import-tree",
+        "rev": "3c23749d8013ec6daa1d7255057590e9ca726646",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vic",
+        "repo": "import-tree",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1769909678,
+        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "72716169fe93074c333e8d0173151350670b824c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1770107345,
+        "narHash": "sha256-tbS0Ebx2PiA1FRW8mt8oejR0qMXmziJmPaU1d4kYY9g=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4533d9293756b63904b7238acb84ac8fe4c8c2c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "bun2nix": "bun2nix",
+        "flake-compat": "flake-compat",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems_2",
+        "treefmt-nix": "treefmt-nix_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "bun2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770228511,
+        "narHash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,138 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    bun2nix = {
+      url = "github:nix-community/bun2nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    systems.url = "github:nix-systems/default";
+    treefmt-nix.url = "github:numtide/treefmt-nix";
+    flake-compat = {
+      url = "github:NixOS/flake-compat";
+      flake = false;
+    };
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      ...
+    }@inputs:
+    with builtins;
+    with nixpkgs.lib;
+
+    let
+      doubles = import inputs.systems;
+      forAllSystems = genAttrs doubles;
+
+      pkgs_gen =
+        { ... }@args:
+        import nixpkgs (
+          {
+            overlays = [ inputs.bun2nix.overlays.default ];
+          }
+          // args
+        );
+
+      importBunLock =
+        { pkgs, src }:
+        pkgs.stdenv.mkDerivation {
+          inherit src;
+
+          name = "bun.nix";
+
+          nativeBuildInputs = with pkgs; [
+            bun2nix
+          ];
+
+          buildPhase = ''
+            bun2nix -o bun.nix
+          '';
+
+          installPhase = ''
+            cp bun.nix $out
+          '';
+        };
+
+      iloader_gen =
+        {
+          pkgs,
+          tools ? [ ],
+          specialArgs ? { },
+        }:
+        pkgs.rustPlatform.buildRustPackage (
+          let
+            src = cleanSource ./.;
+            json = fromJSON (readFile (src + "/package.json"));
+          in
+          final:
+          {
+            pname = json.name;
+            inherit (json) version;
+
+            inherit src;
+            bunDeps = pkgs.bun2nix.fetchBunDeps {
+              bunNix = importBunLock { inherit pkgs src; };
+            };
+            cargoRoot = "src-tauri";
+            cargoLock.lockFile = src + "/${final.cargoRoot}/Cargo.lock";
+            buildAndTestSubdir = final.cargoRoot;
+
+            dontUseBunBuild = true;
+            dontUseBunCheck = true;
+
+            nativeBuildInputs =
+              with pkgs;
+              [
+                cargo-tauri.hook
+                bun2nix.hook
+                pkg-config
+                jq
+                moreutils
+              ]
+              ++ optionals pkgs.stdenv.hostPlatform.isLinux [ wrapGAppsHook4 ]
+              ++ tools;
+
+            buildInputs = optionals pkgs.stdenv.hostPlatform.isLinux (
+              with pkgs;
+              [
+                glib-networking
+                openssl
+                webkitgtk_4_1
+              ]
+            );
+
+            postPatch = ''
+              jq \
+                '.plugins.updater.endpoints = [ ]
+                | .bundle.createUpdaterArtifacts = false' \
+                ${final.cargoRoot}/tauri.conf.json \
+                | sponge ${final.cargoRoot}/tauri.conf.json
+            '';
+          }
+          // specialArgs
+        );
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = pkgs_gen { inherit system; };
+          iloader = iloader_gen { inherit pkgs; };
+        in
+        {
+          inherit iloader;
+          default = iloader;
+        }
+      );
+      formatter = forAllSystems (
+        system:
+        let
+          pkgs = pkgs_gen { inherit system; };
+        in
+        inputs.treefmt-nix.lib.mkWrapper pkgs {
+          programs.nixfmt.enable = true;
+        }
+      );
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,12 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    nodeName = lock.nodes.root.inputs.flake-compat;
+  in
+  fetchTarball {
+    url =
+      lock.nodes.${nodeName}.locked.url
+        or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.${nodeName}.locked.rev}.tar.gz";
+    sha256 = lock.nodes.${nodeName}.locked.narHash;
+  }
+) { src = ./.; }).shellNix


### PR DESCRIPTION
Provide support for the Nix package manager. The following targets are supported, with the mark emojis indicating code testing:

✅ `x86_64-linux`
✅ `x86_64-darwin`
✅ `aarch64-linux`
❓ `aarch64-darwin`

This is achieved using the Nixpkgs derivation builder for Rust, with the `cargo-tauri` hook for build support, as well as the community `bun2nix` hook for reproducible Bun dependency fetching. No hardcoded constants are involved, and in particular no hashes, patchfiles or additional lockfiles are needed, which allows the derivation to keep working over time with little to no maintenance.

The logic is contained within `flake.nix`, thus transforming the Git repo into a flake. The following are valid ways to use it with Nix:

- Building and running the program in a single command: `nix run github:nab138/iloader`
  - The repo can, in turn, be added to the Nix registry (so that the latest version can be launched with e.g. `nix run iloader`)
- Importing the repo into a NixOS configuration as a flake input, with the package being located at `packages.${system}` 
- Cloning the Git repo and using it as a traditional package source (with `nix-{build,shell}` and `NIX_PATH`) thanks to integration via `flake-compat` 

Finally, the `nix-systems` pattern is used to allow users to easily import iLoader on arbitrary architectures, and there is `treefmt-nix` support for Nix styling with `nixfmt`.