### PR TITLE
Add support for Reynard Browser

### DIFF
--- a/src-tauri/src/pairing.rs
+++ b/src-tauri/src/pairing.rs
@@ -51,6 +51,7 @@ const PAIRING_APPS: &[(&str, &str)] = &[
     ("SparseBox", "pairingFile.plist"),
     ("StikStore", "pairingFile.plist"),
     ("ByeTunes", "pairing file/pairingFile.plist"),
+    ("Reynard", "pairingFile.plist"),
 ];
 
 #[derive(Serialize)]


### PR DESCRIPTION
Hi there! I'm working on [Reynard Browser](https://github.com/minh-ton/reynard-browser) - a Gecko-based web browser for iOS 14+. 

Currently, Reynard needs a pairing file so that it can enable JIT in the browser processes for users who sideload using SideStore or AltStore. So having `iloader` to support placing the pairing file directly would be great!