### PR TITLE
fix(i18n): improve zh-CN translation and add missing strings

### DIFF
--- a/src/locales/zh_cn.json
+++ b/src/locales/zh_cn.json
@@ -184,7 +184,9 @@
     "info": "信息",
     "warn": "警告",
     "error": "错误",
-    "language_hint": "您可以<translation>在此</translation>帮助改进翻译。"
+    "language_hint": "您可以<translation>点击这里</translation>帮助我们改进翻译。",
+    "dont_use_keyring": "不使用钥匙串",
+    "dont_use_keyring_message": "勾选此项会让 iloader 将配对文件、anisette 状态和相关证书直接储存在磁盘内，从而使系统更不安全。只有当钥匙串无法正常储存且您充分了解此项的风险时可考虑勾选此项。"
   },
   "dialog": {
     "confirm": "确认",


### PR DESCRIPTION
Hi maintainers,

This PR aims to improve the Simplified Chinese (zh-CN) translation for the `iloader` project. The main changes include:

- **Improved translation quality:** Rewrote several stiff, machine-translated strings to make them sound more natural and native to Chinese users.
- **Added missing translations:** Translated previously untranslated strings to ensure a complete and consistent user experience.

These changes should make the interface much more user-friendly for Chinese-speaking users. Please let me know if any adjustments are needed. Thanks!