### PR TITLE
Add developer team selection

### DIFF
--- a/src-tauri/src/account.rs
+++ b/src-tauri/src/account.rs
@@ -6,14 +6,18 @@ use isideload::{
         app_ids::{AppIdsApi, ListAppIdsResponse},
         certificates::{CertificatesApi, DevelopmentCertificate},
         developer_session::DeveloperSession,
+        teams::DeveloperTeam,
     },
-    sideload::{SideloaderBuilder, builder::MaxCertsBehavior, sideloader::Sideloader},
+    sideload::{
+        SideloaderBuilder, TeamSelection, builder::MaxCertsBehavior, sideloader::Sideloader,
+    },
 };
 use keyring::Entry;
 use rootcause::prelude::*;
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::time::Duration;
+use std::{sync::Mutex, time::Duration};
 use tauri::{AppHandle, Emitter, Listener, State, Window};
 use tauri_plugin_store::StoreExt;
 use tracing::debug;
@@ -23,6 +27,48 @@ use crate::{
     secure_storage::create_sideloading_storage,
     sideload::{SideloaderGuard, SideloaderMutex},
 };
+
+static TEAM_SELECTION_WINDOW: Lazy<Mutex<Option<Window>>> = Lazy::new(|| Mutex::new(None));
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeveloperTeamInfo {
+    name: Option<String>,
+    team_id: String,
+    r#type: Option<String>,
+    status: Option<String>,
+}
+
+impl From<&DeveloperTeam> for DeveloperTeamInfo {
+    fn from(team: &DeveloperTeam) -> Self {
+        Self {
+            name: team.name.clone(),
+            team_id: team.team_id.clone(),
+            r#type: team.r#type.clone(),
+            status: team.status.clone(),
+        }
+    }
+}
+
+fn prompt_for_team(teams: &Vec<DeveloperTeam>) -> Option<String> {
+    let window = TEAM_SELECTION_WINDOW.lock().ok()?.as_ref().cloned()?;
+    let team_infos = teams
+        .iter()
+        .map(DeveloperTeamInfo::from)
+        .collect::<Vec<_>>();
+
+    window.emit("team-selection-required", team_infos).ok()?;
+
+    let (tx, rx) = std::sync::mpsc::channel::<Option<String>>();
+    let handler_id = window.listen("team-selection-response", move |event| {
+        let selection = serde_json::from_str::<Option<String>>(event.payload()).unwrap_or(None);
+        let _ = tx.send(selection);
+    });
+
+    let result = rx.recv_timeout(Duration::from_secs(300));
+    window.unlisten(handler_id);
+    result.unwrap_or(None)
+}
 
 #[tauri::command]
 pub async fn login_new(
@@ -122,6 +168,20 @@ pub fn logged_in_as(sideloader_state: State<'_, SideloaderMutex>) -> Option<Stri
         return Some(account.get_email().to_string());
     }
     None
+}
+
+#[tauri::command]
+pub async fn logged_in_team(
+    sideloader_state: State<'_, SideloaderMutex>,
+) -> Result<Option<DeveloperTeamInfo>, AppError> {
+    let mut sideloader = match SideloaderGuard::take(&sideloader_state) {
+        Ok(sideloader) => sideloader,
+        Err(AppError::NotLoggedIn) => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    let team = sideloader.get_mut().get_team().await?;
+
+    Ok(Some(DeveloperTeamInfo::from(&team)))
 }
 
 #[tauri::command]
@@ -240,13 +300,22 @@ async fn login(
         }
     };
 
-    // TODO: Team Selection
-
-    let sideloader = SideloaderBuilder::new(dev_session, email.to_lowercase())
+    let mut sideloader = SideloaderBuilder::new(dev_session, email.to_lowercase())
         .machine_name("iloader".into())
         .storage(create_sideloading_storage(app)?)
+        .team_selection(TeamSelection::PromptOnce(prompt_for_team))
         .max_certs_behavior(MaxCertsBehavior::Prompt(Box::new(max_certs_callback)))
         .build();
+
+    *TEAM_SELECTION_WINDOW
+        .lock()
+        .map_err(|_| AppError::Misc("Failed to prepare team selection".into()))? =
+        Some(window.clone());
+    let team_result = sideloader.get_team().await;
+    *TEAM_SELECTION_WINDOW
+        .lock()
+        .map_err(|_| AppError::Misc("Failed to clean up team selection".into()))? = None;
+    team_result?;
 
     debug!("Built sideloader");
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,7 +15,8 @@ mod operation;
 use crate::{
     account::{
         delete_account, delete_app_id, get_certificates, invalidate_account, list_app_ids,
-        logged_in_as, login_new, login_stored, reset_anisette_state, revoke_certificate,
+        logged_in_as, logged_in_team, login_new, login_stored, reset_anisette_state,
+        revoke_certificate,
     },
     device::{
         DeviceInfoMutex, PairingCancelToken, cancel_pairing, list_devices, set_selected_device,
@@ -107,6 +108,7 @@ pub fn run() {
             login_new,
             invalidate_account,
             logged_in_as,
+            logged_in_team,
             login_stored,
             delete_account,
             list_devices,

--- a/src/AppleID.css
+++ b/src/AppleID.css
@@ -61,6 +61,28 @@
   color: #fff;
 }
 
+.logged-team {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  margin-top: 0.45rem;
+  padding-top: 0.55rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+.logged-team-label {
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.logged-team-value {
+  color: #fff;
+  font-size: 0.98rem;
+  font-weight: 600;
+}
+
 .credentials h3 {
   margin-bottom: 0.25em;
   margin-top: 1.5em;
@@ -194,4 +216,87 @@
 
 .credentials-warning {
   margin: 0;
+}
+
+.team-selection {
+  display: flex;
+  flex-direction: column;
+  max-height: calc(85vh - 4em - 10px);
+  overflow: hidden;
+}
+
+.team-header {
+  margin-top: 0;
+  flex-shrink: 0;
+}
+
+.team-description {
+  margin-top: 0;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.team-list {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  gap: 0.6rem;
+  max-height: min(50vh, 420px);
+  overflow-y: auto;
+}
+
+.team-item {
+  display: flex;
+  flex-shrink: 0;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.8rem;
+  border: 1px solid var(--glass-border);
+  border-radius: 10px;
+  background: var(--glass-surface);
+  cursor: pointer;
+  transition:
+    border-color 0.2s ease,
+    background 0.2s ease;
+}
+
+.team-item.selected {
+  border-color: var(--accent-secondary);
+  background: rgba(70, 130, 255, 0.14);
+}
+
+.team-item input {
+  margin-top: 0.25rem;
+  accent-color: var(--accent-secondary);
+}
+
+.team-details,
+.team-metadata {
+  display: flex;
+  flex-direction: column;
+}
+
+.team-details {
+  min-width: 0;
+  gap: 0.3rem;
+}
+
+.team-name {
+  color: #fff;
+  font-weight: 600;
+}
+
+.team-metadata {
+  gap: 0.15rem;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  overflow-wrap: anywhere;
+}
+
+.team-buttons {
+  display: flex;
+  flex-shrink: 0;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
 }

--- a/src/AppleID.tsx
+++ b/src/AppleID.tsx
@@ -12,6 +12,13 @@ import { useTranslation } from "react-i18next";
 
 const storePromise = load("data.json");
 
+type DeveloperTeamInfo = {
+  name: string | null;
+  teamId: string;
+  type: string | null;
+  status: string | null;
+};
+
 export const AppleID = ({
   loggedInAs,
   setLoggedInAs,
@@ -37,12 +44,19 @@ export const AppleID = ({
   const [certs, setCerts] = useState<Certificate[] | null>(null);
   const [selectedSerials, setSelectedSerials] = useState<string[]>([]);
   const [chooseCertsOpen, setChooseCertsOpen] = useState<boolean>(false);
+  const [teams, setTeams] = useState<DeveloperTeamInfo[] | null>(null);
+  const [selectedTeamId, setSelectedTeamId] = useState<string>("");
+  const [activeTeam, setActiveTeam] = useState<DeveloperTeamInfo | null>(null);
   const { err } = useError();
 
   useEffect(() => {
     let getLoggedInAs = async () => {
       let account = await invoke<string | null>("logged_in_as");
       setLoggedInAs(account);
+      let team = account
+        ? await invoke<DeveloperTeamInfo | null>("logged_in_team")
+        : null;
+      setActiveTeam(team);
     };
     let getStoredIds = async () => {
       const store = await storePromise;
@@ -97,6 +111,28 @@ export const AppleID = ({
     };
   }, []);
 
+  const teamListenerAdded = useRef<boolean>(false);
+  const teamUnlisten = useRef<() => void>(() => {});
+
+  useEffect(() => {
+    if (!teamListenerAdded.current) {
+      (async () => {
+        const unlistenFn = await listen<DeveloperTeamInfo[]>(
+          "team-selection-required",
+          (event) => {
+            setSelectedTeamId("");
+            setTeams(event.payload);
+          },
+        );
+        teamUnlisten.current = unlistenFn;
+      })();
+      teamListenerAdded.current = true;
+    }
+    return () => {
+      teamUnlisten.current();
+    };
+  }, []);
+
   return (
     <>
       <h2 style={{ marginTop: 0 }}>{t("apple_id.title")}</h2>
@@ -106,6 +142,16 @@ export const AppleID = ({
             <div className="logged-info">
               <span className="logged-label">{t("apple_id.logged_in_as")}</span>
               <span className="logged-value">{loggedInAs}</span>
+              {activeTeam && (
+                <span className="logged-team">
+                  <span className="logged-team-label">
+                    {t("apple_id.developer_team")}
+                  </span>
+                  <span className="logged-team-value">
+                    {activeTeam.name ?? activeTeam.teamId}
+                  </span>
+                </span>
+              )}
             </div>
             <div className="action-row">
               <button
@@ -266,6 +312,77 @@ export const AppleID = ({
           </div>
         )}
       </div>
+      <Modal sizeFit isOpen={teams !== null} zIndex={2000}>
+        <div className="team-selection">
+          <h2 className="team-header">
+            {t("apple_id.team_selection_title")}
+          </h2>
+          <p className="team-description">
+            {t("apple_id.team_selection_prompt")}
+          </p>
+          <div className="team-list" role="radiogroup">
+            {teams?.map((team) => (
+              <label
+                key={team.teamId}
+                className={`team-item${
+                  selectedTeamId === team.teamId ? " selected" : ""
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="developer-team"
+                  value={team.teamId}
+                  checked={selectedTeamId === team.teamId}
+                  onChange={() => setSelectedTeamId(team.teamId)}
+                />
+                <span className="team-details">
+                  <span className="team-name">
+                    {team.name ?? t("apple_id.unnamed_team")}
+                  </span>
+                  <span className="team-metadata">
+                    <span>
+                      {t("apple_id.team_id")}: {team.teamId}
+                    </span>
+                    {team.type && (
+                      <span>
+                        {t("apple_id.team_type")}: {team.type}
+                      </span>
+                    )}
+                    {team.status && (
+                      <span>
+                        {t("apple_id.team_status")}: {team.status}
+                      </span>
+                    )}
+                  </span>
+                </span>
+              </label>
+            ))}
+          </div>
+          <div className="team-buttons">
+            <button
+              className="action-button primary"
+              disabled={!selectedTeamId}
+              onClick={async () => {
+                await emit("team-selection-response", selectedTeamId);
+                setTeams(null);
+                setSelectedTeamId("");
+              }}
+            >
+              {t("common.confirm")}
+            </button>
+            <button
+              className="action-button danger"
+              onClick={async () => {
+                await emit("team-selection-response", null);
+                setTeams(null);
+                setSelectedTeamId("");
+              }}
+            >
+              {t("common.cancel")}
+            </button>
+          </div>
+        </div>
+      </Modal>
       <Modal sizeFit isOpen={tfaOpen} zIndex={2000}>
         <h2>{t("apple_id.two_factor_title")}</h2>
         <p>{t("apple_id.two_factor_prompt")}</p>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -49,6 +49,7 @@
   "apple_id": {
     "title": "Apple ID",
     "logged_in_as": "Logged in as",
+    "developer_team": "Developer Team",
     "sign_out": "Sign Out",
     "signing_out": "Signing Out...",
     "sign_out_failed": "Sign out failed",
@@ -79,6 +80,12 @@
     "hide_certificate_list": "Hide certificate list",
     "choose_what_to_revoke": "Choose what to revoke",
     "continue": "Continue",
+    "team_selection_title": "Choose a Developer Team",
+    "team_selection_prompt": "This account belongs to multiple developer teams. Choose the team to use for signing.",
+    "unnamed_team": "Unnamed Team",
+    "team_id": "Team ID",
+    "team_type": "Type",
+    "team_status": "Status",
     "no_keyring_available": "Unable to save credentials on this device."
   },
   "device": {

--- a/src/locales/zh_cn.json
+++ b/src/locales/zh_cn.json
@@ -49,6 +49,7 @@
   "apple_id": {
     "title": "Apple ID",
     "logged_in_as": "已登录为",
+    "developer_team": "开发者团队",
     "sign_out": "登出",
     "signing_out": "正在登出...",
     "sign_out_failed": "登出失败",
@@ -78,7 +79,13 @@
     "max_certs_desc": "iloader 将撤销您现有的证书并生成一个新的。",
     "hide_certificate_list": "隐藏证书列表",
     "choose_what_to_revoke": "选择要撤销的内容",
-    "continue": "继续"
+    "continue": "继续",
+    "team_selection_title": "选择开发者团队",
+    "team_selection_prompt": "此账户属于多个开发者团队。请选择用于签名的团队。",
+    "unnamed_team": "未命名团队",
+    "team_id": "团队 ID",
+    "team_type": "类型",
+    "team_status": "状态"
   },
   "device": {
     "title": "iDevice",

--- a/src/locales/zh_hk.json
+++ b/src/locales/zh_hk.json
@@ -49,6 +49,7 @@
   "apple_id": {
     "title": "Apple ID",
     "logged_in_as": "登入緊嘅帳戶",
+    "developer_team": "開發者團隊",
     "sign_out": "登出",
     "signing_out": "登出緊...",
     "sign_out_failed": "登出失敗",
@@ -78,7 +79,13 @@
     "max_certs_desc": "iloader 會撤銷你現有嘅憑證，再產生一個新嘅。",
     "hide_certificate_list": "收埋憑證列表",
     "choose_what_to_revoke": "揀要撤銷嘅嘢",
-    "continue": "繼續"
+    "continue": "繼續",
+    "team_selection_title": "揀開發者團隊",
+    "team_selection_prompt": "呢個帳戶屬於多個開發者團隊。請揀用嚟簽署嘅團隊。",
+    "unnamed_team": "未命名團隊",
+    "team_id": "團隊 ID",
+    "team_type": "類型",
+    "team_status": "狀態"
   },
   "device": {
     "title": "iDevice",

--- a/src/locales/zh_tw.json
+++ b/src/locales/zh_tw.json
@@ -49,6 +49,7 @@
   "apple_id": {
     "title": "Apple ID",
     "logged_in_as": "已登入為",
+    "developer_team": "開發者團隊",
     "sign_out": "登出",
     "signing_out": "正在登出...",
     "sign_out_failed": "登出失敗",
@@ -78,7 +79,13 @@
     "max_certs_desc": "iloader 將撤銷您現有的憑證並產生一個新的。",
     "hide_certificate_list": "隱藏憑證列表",
     "choose_what_to_revoke": "選擇要撤銷的內容",
-    "continue": "繼續"
+    "continue": "繼續",
+    "team_selection_title": "選擇開發者團隊",
+    "team_selection_prompt": "此帳戶屬於多個開發者團隊。請選擇用於簽署的團隊。",
+    "unnamed_team": "未命名團隊",
+    "team_id": "團隊 ID",
+    "team_type": "類型",
+    "team_status": "狀態"
   },
   "device": {
     "title": "iDevice",


### PR DESCRIPTION
## Summary

- prompt users to choose a developer team when an Apple ID belongs to multiple teams
- reuse the selected team for signing, certificate, and App ID operations during the login session
- show the active developer team below the logged-in account
- add English, Simplified Chinese, Traditional Chinese, and Cantonese copy for the new UI

## Why

iloader previously used the first team returned by Apple's `listTeams` endpoint. Accounts belonging to multiple teams could therefore sign with an unintended team and had no way to confirm which team was active.

## User impact

Accounts with one team continue without interruption. Accounts with multiple teams must select one during login; canceling or timing out aborts the login instead of silently choosing a team. The selected team name remains visible in the account card for the session.

## Validation

- `cargo check`
- `cargo fmt --check`
- `npm run build`
- `git diff --check`
