### PR TITLE
docs: mention Fedora COPR repository in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 Install SideStore (or other apps) and import your pairing file with ease
 
-**This repository and [iloader.app](https://iloader.app) are the only official ways to download iloader. There is also an unofficial [Homebrew cask](https://formulae.brew.sh/cask/iloader) and an unofficial [AUR package](https://aur.archlinux.org/packages/iloader-bin) maintained by the community. Do not download from any other sources or websites.**
+**This repository and [iloader.app](https://iloader.app) are the only official ways to download iloader. There is also an unofficial [Homebrew cask](https://formulae.brew.sh/cask/iloader), an unofficial [AUR package](https://aur.archlinux.org/packages/iloader-bin), and an unofficial [Fedora COPR repository](https://copr.fedorainfracloud.org/coprs/anudeepd/iloader) maintained by the community. Do not download from any other sources or websites.**
 
 <img width="1918" height="998" alt="iloader0" src="https://github.com/user-attachments/assets/93cd135d-6d89-46ee-9b9f-12c596806911" />
 


### PR DESCRIPTION
Hi! I maintain a Fedora COPR repository that builds and publishes iloader for Fedora users: https://copr.fedorainfracloud.org/coprs/anudeepd/iloader

```bash
sudo dnf copr enable anudeepd/iloader
sudo dnf install iloader
```

This mirrors the existing mentions of the unofficial Homebrew cask and AUR package. I've added a line to the README noting the COPR repository as an unofficial community-maintained option. Thanks for considering!