### PR TITLE
Add PocketJ Launcher to iloader support

### DIFF
--- a/src-tauri/src/pairing.rs
+++ b/src-tauri/src/pairing.rs
@@ -44,6 +44,8 @@ const PAIRING_APPS: &[(&str, &str)] = &[
     ),
     ("Feather", "pairingFile.plist"),
     ("StikDebug", "pairingFile.plist"),
+    ("掌上Java启动器", "pairingFile.plist"),
+    ("PocketJ Launcher", "pairingFile.plist"),
     ("StikDebug (Sideloaded)", "rp_pairing_file.plist"),
     ("StikTest", "stiktest_pairing.plist"),
     ("Protokolle", "pairingFile.plist"),


### PR DESCRIPTION
## Summary

Adds pairing file placement support for PocketJ Launcher.

PocketJ Launcher includes StikJIT integration and reads the combined
Lockdown/RPPairing file from:

`Documents/pairingFile.plist`

The app has two localized display names:

- `PocketJ Launcher`
- `掌上Java启动器`

Both entries use the same `pairingFile.plist` filename.

## User experience

Users can connect their device to iLoader, open pairing file management,
select PocketJ Launcher, and use Place. PocketJ Launcher will then
automatically detect the pairing file for its built-in JIT setup.

## Tested configuration

- iOS 17.4+
- Combined Lockdown/RPPairing plist
- Filename: `pairingFile.plist`