### PR TITLE
bundle: match Linux window identity

### DIFF
--- a/src-tauri/iloader.desktop
+++ b/src-tauri/iloader.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Categories={{categories}}
+{{#if comment}}
+Comment={{comment}}
+{{/if}}
+Exec={{exec}}
+StartupWMClass=Iloader
+Icon={{icon}}
+Name={{name}}
+Terminal=false
+Type=Application
+{{#if mime_type}}
+MimeType={{mime_type}}
+{{/if}}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -42,6 +42,14 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "linux": {
+      "deb": {
+        "desktopTemplate": "iloader.desktop"
+      },
+      "rpm": {
+        "desktopTemplate": "iloader.desktop"
+      }
+    }
   }
 }


### PR DESCRIPTION
Aligns the Linux desktop bundle with the live Iloader window identity. Verified DEB/RPM packaging; AppImage remains blocked by the local split-GLib Nix environment.