### PR TITLE
fix: remove obsolete Vite 8 options

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,14 +8,6 @@ const host = process.env.TAURI_DEV_HOST;
 export default defineConfig(async () => ({
   plugins: [react()],
 
-  esbuild: {
-    target: "es2018",
-  },
-  optimizeDeps: {
-    esbuildOptions: {
-      target: "es2018",
-    },
-  },
   build: {
     target: "es2018",
   },


### PR DESCRIPTION
Removes obsolete Vite 8 options. The build passes; generated JavaScript remains byte-identical (708614 bytes), while the existing chunk warning is unchanged.